### PR TITLE
Remove BH and BH epearl

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 | Name | Version | Support | Source | Development Status |
 |:-:|:-:|:-:|:-:|:-:|
 | [Aristois](https://aristois.net/) | **1.16.5** | [Forum](https://discuss.aristois.net/) | Closed Source | Active |
-| BleachHack | **1.16/1.17** | [Discord](https://discord.com/invite/qQUNcnBc) | [GitHub](https://github.com/BleachDrinker420/bleachhack-1.14) | Active |
-| BleachHack epearl edition | **1.16** | [Discord](https://discord.com/invite/FMNCMnTF) | [GitHub](https://github.com/22s/bleachhack-1.16-epearl-edition) | Active |
 | BubbyClient | **1.16.1** | N/A | [GitHub](https://github.com/BubbyRoosh1/BubbyClient-Fabric-1.16) | Archived |
 | FrostBurn | **1.16.5** | unknown | [GitHub](https://github.com/evaan/FrostBurn) | Active |
 | [Inertia](https://inertiaclient.com/) | **1.16.5** | [Discord](https://discord.com/invite/ZyMKgSm) | Closed Source | Active |


### PR DESCRIPTION
Using the word "hack" on our public index literally defeats the purpose of this. We are trying to show that the naming of "hacked clients" is incorrect and yet we are publicly advertising this.